### PR TITLE
[Feat] publish members page

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -1,0 +1,71 @@
+import { createQueryKeys, mergeQueryKeys } from '@lukemorales/query-key-factory'
+import { API_URL } from './../constant/network'
+
+export const memberApi = {
+  getActiveMembers: async (page = 0, pageSize = 10) => {
+    const response = await fetch(`${API_URL}/admin/members?page=${page}&pageSize=${pageSize}`)
+    return response.json() as Promise<GetActiveMembersReponse>
+  },
+  getWithdrawn: async (page = 0, pageSize = 10) => {
+    const response = await fetch(
+      `${API_URL}/admin/members/withdrawn?page=${page}&pageSize=${pageSize}`,
+    )
+    return response.json() as Promise<GetWithdrawnReponse>
+  },
+  getActiveMembersExcel: async () => {
+    const response = await fetch(`${API_URL}/admin/members/excel`)
+    return response.json() as Promise<GetActiveMembersExcelResponse>
+  },
+  getWithdrawnExcel: async () => {
+    const response = await fetch(`${API_URL}/admin/members/withdrawn/excel`)
+    return response.json() as Promise<GetWithdrawnExcelResponse>
+  },
+}
+
+type BaseResponse<T> = {
+  success: string
+  message: string
+  result?: T
+}
+
+type BaseResult<T> = {
+  totalElements: number
+  totalPages: number
+  currentPage: number
+  pageSize: number
+  hasNext: false
+  content: T
+}
+
+export type MemberData = {
+  memberKey: string // 'naver_123456789'
+  email: string // 'user@naver.com'
+  nickname: string // '홍길동'
+  phoneNumber: string // '010-1234-5678'
+  joinDate: string // '2025-01-15T10:30:00'
+  role: string // '일반회원'
+  provider: string // 'naver'
+}
+
+type WithdrawnData = MemberData & {
+  withdrawalDate: '2025-01-20T14:20:00'
+}
+
+export type GetActiveMembersReponse = BaseResponse<BaseResult<MemberData[]>>
+
+export type GetWithdrawnReponse = BaseResponse<BaseResult<WithdrawnData[]>>
+
+type GetActiveMembersExcelResponse = Blob | BaseResponse<undefined> // excel 파일 반환은 JSON이 아닌 바이너리 타입(Blob)을 반환한다고
+
+type GetWithdrawnExcelResponse = Blob | BaseResponse<undefined>
+
+const memberKey = createQueryKeys('members', {
+  active: (page?: number, pageSize?: number) =>
+    ['active', { page: page ?? 0, pageSize: pageSize ?? 10 }] as const,
+  withdrawn: (page?: number, pageSize?: number) =>
+    ['withdrawn', { page: page ?? 0, pageSize: pageSize ?? 10 }] as const,
+  activeExcel: ['active', 'excel'],
+  withdrawnExcel: ['withdrawn', 'excel'],
+})
+
+export const memberQueryKeys = mergeQueryKeys(memberKey)

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -20,6 +20,16 @@ export const memberApi = {
     const response = await fetch(`${API_URL}/admin/members/withdrawn/excel`)
     return response.json() as Promise<GetWithdrawnExcelResponse>
   },
+  deleteMemberByAdmin: async (memberKey: string) => {
+    const response = await fetch(`${API_URL}/admin/members/delete`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ memberKey }),
+    })
+    return response.json() as Promise<DeleteMemberByAdminResponse>
+  },
 }
 
 type BaseResponse<T> = {
@@ -55,6 +65,8 @@ export type GetActiveMembersReponse = BaseResponse<BaseResult<MemberData[]>>
 
 export type GetWithdrawnReponse = BaseResponse<BaseResult<WithdrawnData[]>>
 
+type DeleteMemberByAdminResponse = BaseResponse<undefined>
+
 type GetActiveMembersExcelResponse = Blob | BaseResponse<undefined> // excel 파일 반환은 JSON이 아닌 바이너리 타입(Blob)을 반환한다고
 
 type GetWithdrawnExcelResponse = Blob | BaseResponse<undefined>
@@ -64,6 +76,7 @@ const memberKey = createQueryKeys('members', {
     ['active', { page: page ?? 0, pageSize: pageSize ?? 10 }] as const,
   withdrawn: (page?: number, pageSize?: number) =>
     ['withdrawn', { page: page ?? 0, pageSize: pageSize ?? 10 }] as const,
+  deleteMember: (memberKey: string) => ['delete', { memberKey: memberKey }] as const,
   activeExcel: ['active', 'excel'],
   withdrawnExcel: ['withdrawn', 'excel'],
 })

--- a/src/components/global-navigation.tsx
+++ b/src/components/global-navigation.tsx
@@ -9,6 +9,8 @@ const GlobalNavigation = () => {
   return (
     <nav className="flex min-w-32 items-center justify-between self-start">
       <NavigationGroup>
+        <NavigationItem to="/members">회원목록</NavigationItem>
+        <NavigationItem to="/members/withdrawn">탈퇴회원목록</NavigationItem>
         <NavigationItem to="/challenges">챌린지관리</NavigationItem>
         {state.location.pathname.startsWith('/challenges') && (
           <Fragment>

--- a/src/hooks/use-members.ts
+++ b/src/hooks/use-members.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query'
+import { memberApi, memberQueryKeys } from '@/api/member'
+
+export const useActiveMembers = (page?: number, pageSize?: number) => {
+  return useQuery({
+    queryKey: memberQueryKeys.members.active(page, pageSize).queryKey,
+    queryFn: () => memberApi.getActiveMembers(page, pageSize),
+  })
+}
+
+export const useWithDrawn = (page?: number, pageSize?: number) => {
+  return useQuery({
+    queryKey: memberQueryKeys.members.withdrawn(page, pageSize).queryKey,
+    queryFn: () => memberApi.getWithdrawn(page, pageSize),
+  })
+}
+
+export const useActiveMembersExcel = () => {
+  return useQuery({
+    queryKey: memberQueryKeys.members.activeExcel.queryKey,
+    queryFn: () => memberApi.getWithdrawn,
+  })
+}
+
+export const useWithDrawnExcel = () => {
+  return useQuery({
+    queryKey: memberQueryKeys.members.withdrawnExcel.queryKey,
+    queryFn: () => memberApi.getWithdrawn,
+  })
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ProductsIndexRouteImport } from './routes/products/index'
 import { Route as PostsIndexRouteImport } from './routes/posts/index'
+import { Route as MembersIndexRouteImport } from './routes/members/index'
 import { Route as ChallengesIndexRouteImport } from './routes/challenges/index'
 import { Route as ProductsCreateRouteImport } from './routes/products/create'
 import { Route as PostsUpsertRouteImport } from './routes/posts/upsert'
@@ -21,6 +22,7 @@ import { Route as ChallengesTeamsRouteImport } from './routes/challenges/teams'
 import { Route as ChallengesCreateRouteImport } from './routes/challenges/create'
 import { Route as ProductsOrdersIndexRouteImport } from './routes/products/orders/index'
 import { Route as ProductsIdIndexRouteImport } from './routes/products/$id/index'
+import { Route as MembersWithdrawnIndexRouteImport } from './routes/members/withdrawn/index'
 import { Route as ChallengesIdIndexRouteImport } from './routes/challenges/$id/index'
 import { Route as ProductsIdUpdateRouteImport } from './routes/products/$id/update'
 import { Route as ChallengesTypeTeamRouteImport } from './routes/challenges/type/team'
@@ -52,6 +54,11 @@ const ProductsIndexRoute = ProductsIndexRouteImport.update({
 const PostsIndexRoute = PostsIndexRouteImport.update({
   id: '/posts/',
   path: '/posts/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MembersIndexRoute = MembersIndexRouteImport.update({
+  id: '/members/',
+  path: '/members/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ChallengesIndexRoute = ChallengesIndexRouteImport.update({
@@ -89,6 +96,11 @@ const ProductsIdIndexRoute = ProductsIdIndexRouteImport.update({
   path: '/products/$id/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const MembersWithdrawnIndexRoute = MembersWithdrawnIndexRouteImport.update({
+  id: '/members/withdrawn/',
+  path: '/members/withdrawn/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ChallengesIdIndexRoute = ChallengesIdIndexRouteImport.update({
   id: '/challenges/$id/',
   path: '/challenges/$id/',
@@ -104,12 +116,11 @@ const ChallengesTypeTeamRoute = ChallengesTypeTeamRouteImport.update({
   path: '/challenges/type/team',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ChallengesTypeIndividualRoute =
-  ChallengesTypeIndividualRouteImport.update({
-    id: '/challenges/type/individual',
-    path: '/challenges/type/individual',
-    getParentRoute: () => rootRouteImport,
-  } as any)
+const ChallengesTypeIndividualRoute = ChallengesTypeIndividualRouteImport.update({
+  id: '/challenges/type/individual',
+  path: '/challenges/type/individual',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ChallengesIdUpdateRoute = ChallengesIdUpdateRouteImport.update({
   id: '/challenges/$id/update',
   path: '/challenges/$id/update',
@@ -137,6 +148,7 @@ export interface FileRoutesByFullPath {
   '/posts/upsert': typeof PostsUpsertRoute
   '/products/create': typeof ProductsCreateRoute
   '/challenges': typeof ChallengesIndexRoute
+  '/members': typeof MembersIndexRoute
   '/posts': typeof PostsIndexRoute
   '/products': typeof ProductsIndexRoute
   '/challenges/$id/update': typeof ChallengesIdUpdateRoute
@@ -144,6 +156,7 @@ export interface FileRoutesByFullPath {
   '/challenges/type/team': typeof ChallengesTypeTeamRoute
   '/products/$id/update': typeof ProductsIdUpdateRoute
   '/challenges/$id': typeof ChallengesIdIndexRoute
+  '/members/withdrawn': typeof MembersWithdrawnIndexRoute
   '/products/$id': typeof ProductsIdIndexRoute
   '/products/orders': typeof ProductsOrdersIndexRoute
   '/challenges/management/verify-status/individual': typeof ChallengesManagementVerifyStatusIndividualRoute
@@ -158,6 +171,7 @@ export interface FileRoutesByTo {
   '/posts/upsert': typeof PostsUpsertRoute
   '/products/create': typeof ProductsCreateRoute
   '/challenges': typeof ChallengesIndexRoute
+  '/members': typeof MembersIndexRoute
   '/posts': typeof PostsIndexRoute
   '/products': typeof ProductsIndexRoute
   '/challenges/$id/update': typeof ChallengesIdUpdateRoute
@@ -165,6 +179,7 @@ export interface FileRoutesByTo {
   '/challenges/type/team': typeof ChallengesTypeTeamRoute
   '/products/$id/update': typeof ProductsIdUpdateRoute
   '/challenges/$id': typeof ChallengesIdIndexRoute
+  '/members/withdrawn': typeof MembersWithdrawnIndexRoute
   '/products/$id': typeof ProductsIdIndexRoute
   '/products/orders': typeof ProductsOrdersIndexRoute
   '/challenges/management/verify-status/individual': typeof ChallengesManagementVerifyStatusIndividualRoute
@@ -180,6 +195,7 @@ export interface FileRoutesById {
   '/posts/upsert': typeof PostsUpsertRoute
   '/products/create': typeof ProductsCreateRoute
   '/challenges/': typeof ChallengesIndexRoute
+  '/members/': typeof MembersIndexRoute
   '/posts/': typeof PostsIndexRoute
   '/products/': typeof ProductsIndexRoute
   '/challenges/$id/update': typeof ChallengesIdUpdateRoute
@@ -187,6 +203,7 @@ export interface FileRoutesById {
   '/challenges/type/team': typeof ChallengesTypeTeamRoute
   '/products/$id/update': typeof ProductsIdUpdateRoute
   '/challenges/$id/': typeof ChallengesIdIndexRoute
+  '/members/withdrawn/': typeof MembersWithdrawnIndexRoute
   '/products/$id/': typeof ProductsIdIndexRoute
   '/products/orders/': typeof ProductsOrdersIndexRoute
   '/challenges/management/verify-status/individual': typeof ChallengesManagementVerifyStatusIndividualRoute
@@ -203,6 +220,7 @@ export interface FileRouteTypes {
     | '/posts/upsert'
     | '/products/create'
     | '/challenges'
+    | '/members'
     | '/posts'
     | '/products'
     | '/challenges/$id/update'
@@ -210,6 +228,7 @@ export interface FileRouteTypes {
     | '/challenges/type/team'
     | '/products/$id/update'
     | '/challenges/$id'
+    | '/members/withdrawn'
     | '/products/$id'
     | '/products/orders'
     | '/challenges/management/verify-status/individual'
@@ -224,6 +243,7 @@ export interface FileRouteTypes {
     | '/posts/upsert'
     | '/products/create'
     | '/challenges'
+    | '/members'
     | '/posts'
     | '/products'
     | '/challenges/$id/update'
@@ -231,6 +251,7 @@ export interface FileRouteTypes {
     | '/challenges/type/team'
     | '/products/$id/update'
     | '/challenges/$id'
+    | '/members/withdrawn'
     | '/products/$id'
     | '/products/orders'
     | '/challenges/management/verify-status/individual'
@@ -245,6 +266,7 @@ export interface FileRouteTypes {
     | '/posts/upsert'
     | '/products/create'
     | '/challenges/'
+    | '/members/'
     | '/posts/'
     | '/products/'
     | '/challenges/$id/update'
@@ -252,6 +274,7 @@ export interface FileRouteTypes {
     | '/challenges/type/team'
     | '/products/$id/update'
     | '/challenges/$id/'
+    | '/members/withdrawn/'
     | '/products/$id/'
     | '/products/orders/'
     | '/challenges/management/verify-status/individual'
@@ -267,6 +290,7 @@ export interface RootRouteChildren {
   PostsUpsertRoute: typeof PostsUpsertRoute
   ProductsCreateRoute: typeof ProductsCreateRoute
   ChallengesIndexRoute: typeof ChallengesIndexRoute
+  MembersIndexRoute: typeof MembersIndexRoute
   PostsIndexRoute: typeof PostsIndexRoute
   ProductsIndexRoute: typeof ProductsIndexRoute
   ChallengesIdUpdateRoute: typeof ChallengesIdUpdateRoute
@@ -274,6 +298,7 @@ export interface RootRouteChildren {
   ChallengesTypeTeamRoute: typeof ChallengesTypeTeamRoute
   ProductsIdUpdateRoute: typeof ProductsIdUpdateRoute
   ChallengesIdIndexRoute: typeof ChallengesIdIndexRoute
+  MembersWithdrawnIndexRoute: typeof MembersWithdrawnIndexRoute
   ProductsIdIndexRoute: typeof ProductsIdIndexRoute
   ProductsOrdersIndexRoute: typeof ProductsOrdersIndexRoute
   ChallengesManagementVerifyStatusIndividualRoute: typeof ChallengesManagementVerifyStatusIndividualRoute
@@ -315,6 +340,13 @@ declare module '@tanstack/react-router' {
       path: '/posts'
       fullPath: '/posts'
       preLoaderRoute: typeof PostsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/members/': {
+      id: '/members/'
+      path: '/members'
+      fullPath: '/members'
+      preLoaderRoute: typeof MembersIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/challenges/': {
@@ -364,6 +396,13 @@ declare module '@tanstack/react-router' {
       path: '/products/$id'
       fullPath: '/products/$id'
       preLoaderRoute: typeof ProductsIdIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/members/withdrawn/': {
+      id: '/members/withdrawn/'
+      path: '/members/withdrawn'
+      fullPath: '/members/withdrawn'
+      preLoaderRoute: typeof MembersWithdrawnIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/challenges/$id/': {
@@ -427,6 +466,7 @@ const rootRouteChildren: RootRouteChildren = {
   PostsUpsertRoute: PostsUpsertRoute,
   ProductsCreateRoute: ProductsCreateRoute,
   ChallengesIndexRoute: ChallengesIndexRoute,
+  MembersIndexRoute: MembersIndexRoute,
   PostsIndexRoute: PostsIndexRoute,
   ProductsIndexRoute: ProductsIndexRoute,
   ChallengesIdUpdateRoute: ChallengesIdUpdateRoute,
@@ -434,12 +474,11 @@ const rootRouteChildren: RootRouteChildren = {
   ChallengesTypeTeamRoute: ChallengesTypeTeamRoute,
   ProductsIdUpdateRoute: ProductsIdUpdateRoute,
   ChallengesIdIndexRoute: ChallengesIdIndexRoute,
+  MembersWithdrawnIndexRoute: MembersWithdrawnIndexRoute,
   ProductsIdIndexRoute: ProductsIdIndexRoute,
   ProductsOrdersIndexRoute: ProductsOrdersIndexRoute,
-  ChallengesManagementVerifyStatusIndividualRoute:
-    ChallengesManagementVerifyStatusIndividualRoute,
-  ChallengesManagementVerifyStatusTeamRoute:
-    ChallengesManagementVerifyStatusTeamRoute,
+  ChallengesManagementVerifyStatusIndividualRoute: ChallengesManagementVerifyStatusIndividualRoute,
+  ChallengesManagementVerifyStatusTeamRoute: ChallengesManagementVerifyStatusTeamRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/members/index.tsx
+++ b/src/routes/members/index.tsx
@@ -6,9 +6,10 @@ import FilePresentIcon from '@mui/icons-material/FilePresent'
 import { Separator } from '@radix-ui/react-select'
 import { createFileRoute } from '@tanstack/react-router'
 import { DataGrid, type GridColDef } from '@mui/x-data-grid'
-import type { MemberData } from '@/api/member'
+import { memberApi, type MemberData } from '@/api/member'
 import { Button } from '@/components/shadcn/button'
 import { useActiveMembers } from '@/hooks/use-members'
+import { toast } from 'sonner'
 
 export const Route = createFileRoute('/members/')({
   component: RouteComponent,
@@ -68,32 +69,47 @@ const columns: GridColDef<MemberData>[] = [
     align: 'center',
     flex: 1,
     sortable: false,
-    renderCell: () => (
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '100%',
-          width: '100%',
-        }}
-      >
-        <button
+    renderCell: (params) => {
+      const memberKey = params.row.memberKey
+      return (
+        <div
           style={{
             display: 'flex',
-            justifyContent: 'center',
             alignItems: 'center',
-            fontSize: '12px',
-            width: '60px',
-            height: '28px',
-            border: '1px solid #ccc',
-            borderRadius: '4px',
-            cursor: 'pointer',
+            justifyContent: 'center',
+            height: '100%',
+            width: '100%',
           }}
         >
-          삭제
-        </button>
-      </div>
-    ),
+          <button
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              fontSize: '12px',
+              width: '60px',
+              height: '28px',
+              border: '1px solid #ccc',
+              borderRadius: '4px',
+              cursor: 'pointer',
+            }}
+            onClick={async (e) => {
+              e.stopPropagation()
+              if (window.confirm('정말 이 회원을 삭제하시겠습니까?')) {
+                //@TODO 여기도 modal이 있어야 하지 않을까 싶습니다.
+                const res = await memberApi.deleteMemberByAdmin(memberKey)
+                if (res.success) toast.success('회원 삭제에 성공했습니다.')
+
+                setTimeout(() => {
+                  window.location.reload()
+                }, 1500)
+              }
+            }}
+          >
+            삭제
+          </button>
+        </div>
+      )
+    },
   },
 ]

--- a/src/routes/members/index.tsx
+++ b/src/routes/members/index.tsx
@@ -1,0 +1,99 @@
+import GlobalNavigation from '@/components/global-navigation'
+import dayjs from 'dayjs'
+import PageContainer from '@/components/page-container'
+import PageTitle from '@/components/page-title'
+import FilePresentIcon from '@mui/icons-material/FilePresent'
+import { Separator } from '@radix-ui/react-select'
+import { createFileRoute } from '@tanstack/react-router'
+import { DataGrid, type GridColDef } from '@mui/x-data-grid'
+import type { MemberData } from '@/api/member'
+import { Button } from '@/components/shadcn/button'
+import { useActiveMembers } from '@/hooks/use-members'
+
+export const Route = createFileRoute('/members/')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const { data } = useActiveMembers()
+  if (!data) return <div>데이터를 불러오는 중...</div> //@TODO fallback ui로 대체될 예정 (기획 미정)
+  if (!data.result?.content) return <div>리스트가 없습니다..</div>
+
+  const downloadExcel = () => {
+    // @TODO 엑셀 다운로드 api 연결 예정
+  }
+
+  return (
+    <PageContainer className="flex-row">
+      <GlobalNavigation />
+      <div className="flex w-full flex-col gap-4">
+        <PageTitle className="self-start">회원 목록</PageTitle>
+        <Separator />
+        <div className="flex justify-between">
+          <span className="text-2xl">Title : {data.result?.totalElements}</span>
+          <Button className="w-fit" onClick={downloadExcel}>
+            <FilePresentIcon />
+            엑셀 받기
+          </Button>
+        </div>
+        <div className="flex w-full">
+          <DataGrid
+            rows={data.result?.content.map((item) => ({
+              ...item,
+              id: item.memberKey,
+              joinDate: dayjs(item.joinDate).format('YYYY-MM-DD'),
+            }))}
+            columns={columns}
+            initialState={{
+              pagination: { paginationModel: { page: 0, pageSize: 10 } },
+            }}
+          />
+        </div>
+      </div>
+    </PageContainer>
+  )
+}
+
+const columns: GridColDef<MemberData>[] = [
+  { field: 'memberKey', headerName: 'MemberKey', flex: 1, headerAlign: 'center', align: 'center' },
+  { field: 'email', headerName: '이메일', flex: 1, headerAlign: 'center', align: 'center' },
+  { field: 'nickname', headerName: '닉네임', flex: 1, headerAlign: 'center', align: 'center' },
+  { field: 'phoneNumber', headerName: '전화번호', flex: 1, headerAlign: 'center', align: 'center' },
+  { field: 'joinDate', headerName: '가입일', flex: 1, headerAlign: 'center', align: 'center' },
+  { field: 'role', headerName: '등급', flex: 1, headerAlign: 'center', align: 'center' },
+  {
+    field: 'actions',
+    headerName: '관리',
+    headerAlign: 'center',
+    align: 'center',
+    flex: 1,
+    sortable: false,
+    renderCell: () => (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100%',
+          width: '100%',
+        }}
+      >
+        <button
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            fontSize: '12px',
+            width: '60px',
+            height: '28px',
+            border: '1px solid #ccc',
+            borderRadius: '4px',
+            cursor: 'pointer',
+          }}
+        >
+          삭제
+        </button>
+      </div>
+    ),
+  },
+]

--- a/src/routes/members/withdrawn/index.tsx
+++ b/src/routes/members/withdrawn/index.tsx
@@ -1,14 +1,14 @@
+import dayjs from 'dayjs'
 import GlobalNavigation from '@/components/global-navigation'
 import PageContainer from '@/components/page-container'
 import PageTitle from '@/components/page-title'
 import FilePresentIcon from '@mui/icons-material/FilePresent'
+import { createFileRoute } from '@tanstack/react-router'
+import type { MemberData } from '@/api/member'
+import { DataGrid, type GridColDef } from '@mui/x-data-grid'
 import { Button } from '@/components/shadcn/button'
 import { useWithDrawn } from '@/hooks/use-members'
 import { Separator } from '@radix-ui/react-select'
-import { createFileRoute } from '@tanstack/react-router'
-import { DataGrid, type GridColDef } from '@mui/x-data-grid'
-import type { MemberData } from '@/api/member'
-import dayjs from 'dayjs'
 
 export const Route = createFileRoute('/members/withdrawn/')({
   component: RouteComponent,

--- a/src/routes/members/withdrawn/index.tsx
+++ b/src/routes/members/withdrawn/index.tsx
@@ -1,0 +1,79 @@
+import GlobalNavigation from '@/components/global-navigation'
+import PageContainer from '@/components/page-container'
+import PageTitle from '@/components/page-title'
+import FilePresentIcon from '@mui/icons-material/FilePresent'
+import { Button } from '@/components/shadcn/button'
+import { useWithDrawn } from '@/hooks/use-members'
+import { Separator } from '@radix-ui/react-select'
+import { createFileRoute } from '@tanstack/react-router'
+import { DataGrid, type GridColDef } from '@mui/x-data-grid'
+import type { MemberData } from '@/api/member'
+import dayjs from 'dayjs'
+
+export const Route = createFileRoute('/members/withdrawn/')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const { data } = useWithDrawn()
+  if (!data) return <div>데이터를 불러오는 중...</div> //@TODO fallback ui로 대체될 예정 (기획 미정)
+  if (!data.result?.content) return <div>리스트가 없습니다..</div>
+
+  const downloadExcel = () => {
+    // @TODO 엑셀 다운로드 api 연결 예정
+  }
+
+  return (
+    <PageContainer className="flex-row">
+      <GlobalNavigation />
+      <div className="flex w-full flex-col gap-4">
+        <PageTitle className="self-start">탈퇴회원목록</PageTitle>
+        <Separator />
+        <div className="flex justify-between">
+          <span className="text-2xl">Title : {data.result?.totalElements}</span>
+          <Button className="w-fit" onClick={downloadExcel}>
+            <FilePresentIcon />
+            엑셀 받기
+          </Button>
+        </div>
+        <div className="flex w-full">
+          <DataGrid
+            rows={data.result?.content.map((item) => ({
+              ...item,
+              id: item.memberKey,
+              joinDate: dayjs(item.joinDate).format('YYYY-MM-DD'),
+              withdrawalDate: dayjs(item.withdrawalDate).format('YYYY-MM-DD'),
+            }))}
+            columns={columns}
+            initialState={{
+              pagination: { paginationModel: { page: 0, pageSize: 10 } },
+            }}
+          />
+        </div>
+      </div>
+    </PageContainer>
+  )
+}
+
+const columns: GridColDef<MemberData>[] = [
+  { field: 'memberKey', headerName: 'MemberKey', flex: 1, headerAlign: 'center', align: 'center' },
+  { field: 'email', headerName: '이메일', flex: 1, headerAlign: 'center', align: 'center' },
+  { field: 'nickname', headerName: '닉네임', flex: 1, headerAlign: 'center', align: 'center' },
+  { field: 'phoneNumber', headerName: '전화번호', flex: 1, headerAlign: 'center', align: 'center' },
+  {
+    field: 'joinDate',
+    headerName: '가입일',
+    flex: 1,
+    headerAlign: 'center',
+    align: 'center',
+  },
+
+  {
+    field: 'withdrawalDate',
+    headerName: '탈퇴일',
+    flex: 1,
+    headerAlign: 'center',
+    align: 'center',
+  },
+  { field: 'role', headerName: '등급', flex: 1, headerAlign: 'center', align: 'center' },
+]


### PR DESCRIPTION
## 🔗 관련 이슈 : #2 

## 📌 개요
회원목록, 탈퇴회원 목록 페이지 퍼블리싱 작업입니다.

## 🔍 작업 유형
- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 스타일 변경 (style)
- [ ] 설정 변경 (chore)
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세
1. 데이터가 없을 떄 어떤 ui를 보여줄 지는 아직 기획이 없는 것 같아 깊게 다루지 않았습니다.
2. 엑셀 다운로드 api 연결해야 합니다. 아직 어떻게 해야할지 몰라 기존에 작업하신 것도 있는 것 같아서 섣불리 진행하지 않았습니다.
3. 삭제하기 버튼 api 연결 했습니다. -> 한번 탈퇴하면 재가입이 불가능하다보니 일단은 window.confirm이 뜨고 확인을 눌러야지만 진행되게 했습니다., 모달이 있으면 좋을지 궁금합니다.

## 🖼️ 화면 스크린샷 (Optional)
https://github.com/user-attachments/assets/32a09bc0-ee3b-44bf-a310-98eecf2992d1