### PR TITLE
chore: apply feedback from PR #28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@mui/icons-material": "^7.2.0",
         "@mui/material": "^7.2.0",
         "@mui/x-data-grid": "^8.9.1",
+        "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-label": "^2.1.7",
@@ -2468,6 +2469,34 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.14.tgz",
+      "integrity": "sha512-IOZfZ3nPvN6lXpJTBCunFQPRSvK8MDgSc1FB85xnIpUKOw9en0dJj8JmCAxV7BiZdtYlUpmrQjoTFkVYtdoWzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.14",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "react-router": "^7.6.3",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
-        "tailwind-scrollbar-hide": "^4.0.0",
         "whatwg-fetch": "^3.6.20",
         "zod": "^4.0.5",
         "zustand": "^5.0.6"
@@ -9500,19 +9499,11 @@
         "url": "https://github.com/sponsors/dcastil"
       }
     },
-    "node_modules/tailwind-scrollbar-hide": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-4.0.0.tgz",
-      "integrity": "sha512-gobtvVcThB2Dxhy0EeYSS1RKQJ5baDFkamkhwBvzvevwX6L4XQfpZ3me9s25Ss1ecFVT5jPYJ50n+7xTBJG9WQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || >= 4.0.0 || >= 4.0.0-beta.8 || >= 4.0.0-alpha.20"
-      }
-    },
     "node_modules/tailwindcss": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
       "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "react-router": "^7.6.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
-    "tailwind-scrollbar-hide": "^4.0.0",
     "whatwg-fetch": "^3.6.20",
     "zod": "^4.0.5",
     "zustand": "^5.0.6"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@mui/icons-material": "^7.2.0",
     "@mui/material": "^7.2.0",
     "@mui/x-data-grid": "^8.9.1",
+    "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -38,7 +38,7 @@ type BaseResponse<T> = {
   result?: T
 }
 
-type BaseResult<T> = {
+type PaginatedData<T> = {
   totalElements: number
   totalPages: number
   currentPage: number
@@ -47,7 +47,7 @@ type BaseResult<T> = {
   content: T
 }
 
-export type MemberData = {
+export type Member = {
   memberKey: string // 'naver_123456789'
   email: string // 'user@naver.com'
   nickname: string // '홍길동'
@@ -57,17 +57,17 @@ export type MemberData = {
   provider: string // 'naver'
 }
 
-type WithdrawnData = MemberData & {
+type WithdrawnData = Member & {
   withdrawalDate: '2025-01-20T14:20:00'
 }
 
-export type GetActiveMembersReponse = BaseResponse<BaseResult<MemberData[]>>
+export type GetActiveMembersReponse = BaseResponse<PaginatedData<Member[]>>
 
-export type GetWithdrawnReponse = BaseResponse<BaseResult<WithdrawnData[]>>
+export type GetWithdrawnReponse = BaseResponse<PaginatedData<WithdrawnData[]>>
 
 type DeleteMemberByAdminResponse = BaseResponse<undefined>
 
-type GetActiveMembersExcelResponse = Blob | BaseResponse<undefined> // excel 파일 반환은 JSON이 아닌 바이너리 타입(Blob)을 반환한다고
+type GetActiveMembersExcelResponse = Blob | BaseResponse<undefined>
 
 type GetWithdrawnExcelResponse = Blob | BaseResponse<undefined>
 

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -1,5 +1,6 @@
 import { createQueryKeys, mergeQueryKeys } from '@lukemorales/query-key-factory'
 import { API_URL } from './../constant/network'
+import { downloadExcel } from '@/lib/network'
 
 export const memberApi = {
   getActiveMembers: async (page = 0, pageSize = 10) => {
@@ -14,11 +15,11 @@ export const memberApi = {
   },
   getActiveMembersExcel: async () => {
     const response = await fetch(`${API_URL}/admin/members/excel`)
-    return response.json() as Promise<GetActiveMembersExcelResponse>
+    await downloadExcel(response)
   },
   getWithdrawnExcel: async () => {
     const response = await fetch(`${API_URL}/admin/members/withdrawn/excel`)
-    return response.json() as Promise<GetWithdrawnExcelResponse>
+    await downloadExcel(response)
   },
   deleteMemberByAdmin: async (memberKey: string) => {
     const response = await fetch(`${API_URL}/admin/members/delete`, {
@@ -66,10 +67,6 @@ export type GetActiveMembersReponse = BaseResponse<PaginatedData<Member[]>>
 export type GetWithdrawnReponse = BaseResponse<PaginatedData<WithdrawnData[]>>
 
 type DeleteMemberByAdminResponse = BaseResponse<undefined>
-
-type GetActiveMembersExcelResponse = Blob | BaseResponse<undefined>
-
-type GetWithdrawnExcelResponse = Blob | BaseResponse<undefined>
 
 const memberKey = createQueryKeys('members', {
   active: (page?: number, pageSize?: number) =>

--- a/src/components/dialog/AllertDialog.tsx
+++ b/src/components/dialog/AllertDialog.tsx
@@ -1,0 +1,33 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/shadcn/alert-dialog'
+
+function AllertDialog({ onClick, trigger }: { onClick: () => void; trigger: React.ReactNode }) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+      <AlertDialogContent onClick={(e) => e.stopPropagation()}>
+        <AlertDialogHeader>
+          <AlertDialogTitle>회원 삭제</AlertDialogTitle>
+          <AlertDialogDescription>
+            이 작업은 되돌릴 수 없습니다. 해당 회원을 정말로 삭제하시겠습니까?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={(e) => e.stopPropagation()}>취소</AlertDialogCancel>
+          <AlertDialogAction onClick={onClick}>삭제</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export default AllertDialog

--- a/src/components/shadcn/alert-dialog.tsx
+++ b/src/components/shadcn/alert-dialog.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react'
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
+
+import { cn } from '@/lib/utils'
+import { buttonVariants } from '@/components/shadcn/button'
+
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+}
+
+function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn('text-lg font-semibold', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return <AlertDialogPrimitive.Action className={cn(buttonVariants(), className)} {...props} />
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: 'outline' }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,5 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
-@import 'tailwind-scrollbar-hide/v4';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/routes/members/index.tsx
+++ b/src/routes/members/index.tsx
@@ -29,7 +29,7 @@ function RouteComponent() {
         <PageTitle className="self-start">회원 목록</PageTitle>
         <Separator />
         <div className="flex justify-between">
-          <span className="text-2xl">Title : {data.result?.totalElements}</span>
+          <span className="text-2xl">Total : {data.result?.totalElements}</span>
           <Button className="w-fit" onClick={() => postApi.downloadExcel()}>
             <FilePresentIcon />
             엑셀 받기

--- a/src/routes/members/index.tsx
+++ b/src/routes/members/index.tsx
@@ -10,8 +10,8 @@ import { memberApi, type Member } from '@/api/member'
 import { Button } from '@/components/shadcn/button'
 import { useActiveMembers } from '@/hooks/use-members'
 import { toast } from 'sonner'
-import { postApi } from '@/api/post'
 import AllertDialog from '@/components/dialog/AllertDialog'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 export const Route = createFileRoute('/members/')({
   component: RouteComponent,
@@ -19,8 +19,66 @@ export const Route = createFileRoute('/members/')({
 
 function RouteComponent() {
   const { data } = useActiveMembers()
+  const queryClient = useQueryClient()
+  const { mutate: deleteMutation } = useMutation({
+    mutationFn: (memberKey: string) => memberApi.deleteMemberByAdmin(memberKey),
+    onSuccess: async () => {
+      toast.success('회원 삭제에 성공했습니다.')
+      await queryClient.invalidateQueries({ queryKey: ['members'] })
+    },
+  })
+
   if (!data) return <div>데이터를 불러오는 중...</div> //@TODO fallback ui로 대체될 예정 (기획 미정)
   if (!data.result?.content) return <div>리스트가 없습니다..</div>
+
+  const columns: GridColDef<Member>[] = [
+    {
+      field: 'memberKey',
+      headerName: 'MemberKey',
+      flex: 1,
+      headerAlign: 'center',
+      align: 'center',
+    },
+    { field: 'email', headerName: '이메일', flex: 1, headerAlign: 'center', align: 'center' },
+    { field: 'nickname', headerName: '닉네임', flex: 1, headerAlign: 'center', align: 'center' },
+    {
+      field: 'phoneNumber',
+      headerName: '전화번호',
+      flex: 1,
+      headerAlign: 'center',
+      align: 'center',
+    },
+    { field: 'joinDate', headerName: '가입일', flex: 1, headerAlign: 'center', align: 'center' },
+    { field: 'role', headerName: '등급', flex: 1, headerAlign: 'center', align: 'center' },
+    {
+      field: 'actions',
+      headerName: '관리',
+      headerAlign: 'center',
+      align: 'center',
+      flex: 1,
+      sortable: false,
+      renderCell: (params) => {
+        const memberKey = params.row.memberKey
+        return (
+          <div className="flex h-full w-full items-center justify-center">
+            <AllertDialog
+              trigger={
+                <button
+                  className="flex h-[28px] w-[60px] cursor-pointer items-center justify-center rounded border border-gray-300 text-[12px]"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  삭제
+                </button>
+              }
+              onClick={() => {
+                deleteMutation(memberKey)
+              }}
+            />
+          </div>
+        )
+      },
+    },
+  ]
 
   return (
     <PageContainer className="flex-row">
@@ -30,7 +88,7 @@ function RouteComponent() {
         <Separator />
         <div className="flex justify-between">
           <span className="text-2xl">Total : {data.result?.totalElements}</span>
-          <Button className="w-fit" onClick={() => postApi.downloadExcel()}>
+          <Button className="w-fit" onClick={memberApi.getActiveMembersExcel}>
             <FilePresentIcon />
             엑셀 받기
           </Button>
@@ -52,44 +110,3 @@ function RouteComponent() {
     </PageContainer>
   )
 }
-
-const columns: GridColDef<Member>[] = [
-  { field: 'memberKey', headerName: 'MemberKey', flex: 1, headerAlign: 'center', align: 'center' },
-  { field: 'email', headerName: '이메일', flex: 1, headerAlign: 'center', align: 'center' },
-  { field: 'nickname', headerName: '닉네임', flex: 1, headerAlign: 'center', align: 'center' },
-  { field: 'phoneNumber', headerName: '전화번호', flex: 1, headerAlign: 'center', align: 'center' },
-  { field: 'joinDate', headerName: '가입일', flex: 1, headerAlign: 'center', align: 'center' },
-  { field: 'role', headerName: '등급', flex: 1, headerAlign: 'center', align: 'center' },
-  {
-    field: 'actions',
-    headerName: '관리',
-    headerAlign: 'center',
-    align: 'center',
-    flex: 1,
-    sortable: false,
-    renderCell: (params) => {
-      const memberKey = params.row.memberKey
-      return (
-        <div className="flex h-full w-full items-center justify-center">
-          <AllertDialog
-            trigger={
-              <button
-                className="flex h-[28px] w-[60px] cursor-pointer items-center justify-center rounded border border-gray-300 text-[12px]"
-                onClick={(e) => e.stopPropagation()}
-              >
-                삭제
-              </button>
-            }
-            onClick={async () => {
-              const res = await memberApi.deleteMemberByAdmin(memberKey)
-              if (res.success) toast.success('회원 삭제에 성공했습니다.')
-              setTimeout(() => {
-                window.location.reload()
-              }, 1500)
-            }}
-          />
-        </div>
-      )
-    },
-  },
-]

--- a/src/routes/members/withdrawn/index.tsx
+++ b/src/routes/members/withdrawn/index.tsx
@@ -4,11 +4,12 @@ import PageContainer from '@/components/page-container'
 import PageTitle from '@/components/page-title'
 import FilePresentIcon from '@mui/icons-material/FilePresent'
 import { createFileRoute } from '@tanstack/react-router'
-import type { MemberData } from '@/api/member'
+import type { Member } from '@/api/member'
 import { DataGrid, type GridColDef } from '@mui/x-data-grid'
 import { Button } from '@/components/shadcn/button'
 import { useWithDrawn } from '@/hooks/use-members'
 import { Separator } from '@radix-ui/react-select'
+import { postApi } from '@/api/post'
 
 export const Route = createFileRoute('/members/withdrawn/')({
   component: RouteComponent,
@@ -19,10 +20,6 @@ function RouteComponent() {
   if (!data) return <div>데이터를 불러오는 중...</div> //@TODO fallback ui로 대체될 예정 (기획 미정)
   if (!data.result?.content) return <div>리스트가 없습니다..</div>
 
-  const downloadExcel = () => {
-    // @TODO 엑셀 다운로드 api 연결 예정
-  }
-
   return (
     <PageContainer className="flex-row">
       <GlobalNavigation />
@@ -31,7 +28,7 @@ function RouteComponent() {
         <Separator />
         <div className="flex justify-between">
           <span className="text-2xl">Title : {data.result?.totalElements}</span>
-          <Button className="w-fit" onClick={downloadExcel}>
+          <Button className="w-fit" onClick={() => postApi.downloadExcel()}>
             <FilePresentIcon />
             엑셀 받기
           </Button>
@@ -55,7 +52,7 @@ function RouteComponent() {
   )
 }
 
-const columns: GridColDef<MemberData>[] = [
+const columns: GridColDef<Member>[] = [
   { field: 'memberKey', headerName: 'MemberKey', flex: 1, headerAlign: 'center', align: 'center' },
   { field: 'email', headerName: '이메일', flex: 1, headerAlign: 'center', align: 'center' },
   { field: 'nickname', headerName: '닉네임', flex: 1, headerAlign: 'center', align: 'center' },

--- a/src/routes/members/withdrawn/index.tsx
+++ b/src/routes/members/withdrawn/index.tsx
@@ -4,12 +4,11 @@ import PageContainer from '@/components/page-container'
 import PageTitle from '@/components/page-title'
 import FilePresentIcon from '@mui/icons-material/FilePresent'
 import { createFileRoute } from '@tanstack/react-router'
-import type { Member } from '@/api/member'
+import { memberApi, type Member } from '@/api/member'
 import { DataGrid, type GridColDef } from '@mui/x-data-grid'
 import { Button } from '@/components/shadcn/button'
 import { useWithDrawn } from '@/hooks/use-members'
 import { Separator } from '@radix-ui/react-select'
-import { postApi } from '@/api/post'
 
 export const Route = createFileRoute('/members/withdrawn/')({
   component: RouteComponent,
@@ -28,7 +27,7 @@ function RouteComponent() {
         <Separator />
         <div className="flex justify-between">
           <span className="text-2xl">Title : {data.result?.totalElements}</span>
-          <Button className="w-fit" onClick={() => postApi.downloadExcel()}>
+          <Button className="w-fit" onClick={memberApi.getWithdrawnExcel}>
             <FilePresentIcon />
             엑셀 받기
           </Button>


### PR DESCRIPTION
## 📌 개요
#28 PR에서 발생한 코멘트 반영한 작업입니다.

## 🔍 작업 유형
- [x] 기능 추가 (feat)
- [] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 스타일 변경 (style)
- [ ] 설정 변경 (chore)
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세
0. /api/member.ts에 일부 type 네이밍 수정했습니다.
1. 엑셀 받기 버튼 눌렀을 때 postApi.downloadExcel 호출하도록 했습니다.
2. shadcn alert-dialog를 add 햇습니다. 삭제하기 버튼 눌렀을 때 기존에 alert가 아닌 모달이 뜨도록 했습니다.
3. 회원 목록 페이지에서만 렌더링 되는 전체 회원 수 (Total)이 있는데, Title로 오타 표기된 부분을 수정했습니다.
