### PR TITLE
[Feat] 아이템 등록 api 연동

### DIFF
--- a/src/api/item.ts
+++ b/src/api/item.ts
@@ -1,0 +1,24 @@
+import { API_URL } from '@/constant/network'
+import { throwResponseStatusThenChaining } from '@/lib/network'
+
+export const itemApi = {
+  createItem: async (params: {
+    code: string
+    name: string
+    description: string
+    thumbnailUrl: string
+    price: number
+  }) => {
+    return await fetch(`${API_URL}/admin/point-items`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(params),
+    })
+      .then(throwResponseStatusThenChaining)
+      .catch((error) => {
+        throw error
+      })
+  },
+}

--- a/src/api/product.ts
+++ b/src/api/product.ts
@@ -36,7 +36,7 @@ export const productApi = {
     description: string
     thumbnailUrl: string
     price: number
-    stock: number
+    stock: number | null
   }) => {
     return await fetch(`${API_URL}/admin/point-products`, {
       method: 'POST',

--- a/src/components/products/type.ts
+++ b/src/components/products/type.ts
@@ -1,12 +1,12 @@
 import type { SubmitHandler } from 'react-hook-form'
 
-export interface FormState {
+export type FormState = {
   code: string
   name: string
   description: string
   thumbnailUrl: string | null
   price: number
-  stock: number
+  stock: number | null
 }
 
 export interface UpsertFormProps {
@@ -15,4 +15,6 @@ export interface UpsertFormProps {
     Omit<FormState, 'thumbnailUrl'> & { thumbnailUrl: NonNullable<FormState['thumbnailUrl']> }
   >
   renderBackButton?: boolean
+  category?: '배송상품' | '아이템'
+  categoryOnChange?: (category: '배송상품' | '아이템') => void
 }

--- a/src/components/products/upsert-form.tsx
+++ b/src/components/products/upsert-form.tsx
@@ -84,7 +84,10 @@ const UpsertForm = ({
           <tr>
             <th>상품코드</th>
             <td>
-              <Input {...form.register('code')} placeholder="PRD-AA-000" />
+              <Input
+                {...form.register('code')}
+                placeholder={category === '배송상품' ? 'PRD-AA-000' : 'ITM-AA-000'}
+              />
             </td>
           </tr>
           <tr>

--- a/src/hooks/item/use-create-item.ts
+++ b/src/hooks/item/use-create-item.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query'
+import { postsQueryKeys } from '@/api/post'
+import { itemApi } from '@/api/item'
+import { useNavigate } from '@tanstack/react-router'
+
+export interface CreateItemParams {
+  code: string
+  name: string
+  description: string
+  thumbnailUrl: string
+  price: number
+}
+
+const useCreateItem = () => {
+  const navigate = useNavigate()
+  return useMutation({
+    mutationKey: postsQueryKeys.getCategories.queryKey,
+    mutationFn: ({ code, description, name, price, thumbnailUrl }: CreateItemParams) =>
+      itemApi.createItem({ code, description, name, price, thumbnailUrl }),
+    onSuccess: () => {
+      navigate({ to: '/products' })
+    },
+  })
+}
+
+export default useCreateItem

--- a/src/routes/products/create.tsx
+++ b/src/routes/products/create.tsx
@@ -5,8 +5,10 @@ import PageTitle from '@/components/page-title'
 import type { UpsertFormProps } from '@/components/products/type'
 import UpsertForm from '@/components/products/upsert-form'
 import { DEFAULT_PAGINATION_MODEL } from '@/constant/pagination'
+import useCreateItem from '@/hooks/item/use-create-item'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
 import { toast } from 'sonner'
 
 export const Route = createFileRoute('/products/create')({
@@ -35,16 +37,35 @@ function CreateProduct() {
     },
   })
 
+  const { mutate: createItem } = useCreateItem()
+
   const onSubmit: UpsertFormProps['onSubmit'] = (data) => {
-    createProduct(data)
+    return category === '배송상품'
+      ? createProduct(data)
+      : createItem({
+          code: data.code,
+          name: data.name,
+          description: data.description,
+          thumbnailUrl: data.thumbnailUrl,
+          price: Number(data.price),
+        })
   }
 
+  const [category, setCategory] = useState<'배송상품' | '아이템'>('배송상품')
+  const categoryOnChange = (categoryStr: '배송상품' | '아이템') => {
+    setCategory(categoryStr)
+  }
   return (
     <PageContainer className="flex-row">
       <GlobalNavigation />
       <div className="flex flex-col gap-4">
         <PageTitle>상품 등록</PageTitle>
-        <UpsertForm onSubmit={onSubmit} renderBackButton />
+        <UpsertForm
+          categoryOnChange={categoryOnChange}
+          category={category}
+          onSubmit={onSubmit}
+          renderBackButton
+        />
       </div>
     </PageContainer>
   )


### PR DESCRIPTION
## 🔗 관련 이슈 : (#번호)

## 📌 개요
아이템 등록 api 연동

## 🔍 작업 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 스타일 변경 (style)
- [ ] 설정 변경 (chore)
- [ ] 테스트 코드 추가 또는 수정 (test)
- [ ] CI/CD (ci)

## 🧩 작업 상세
기존 배송상품 등록만 있던 것을 카테고리 tab을 추가해 "배송상품"|"아이템" 을 선택해 아이템 까지 따로 등록할 수 있도록 구분
아이템 등록 api 연동

## 🖼️ 화면 스크린샷 (Optional)
<img width="1041" height="694" alt="image" src="https://github.com/user-attachments/assets/82a27e50-1578-4235-9da0-39c4ba592afc" />

## 💬 리뷰 요구사항 (Optional)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요. -->
